### PR TITLE
cluster config

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -338,7 +338,7 @@ meta:
                 "overrides": {
                   "Instances": {"KeepJobFlowAliveWhenNoSteps": true},
                   "Steps": [{
-                    "Name": "TEST",
+                    "Name": "corporate-data-ingestion::$EXPORT_START_DATE-$EXPORT_END_DATE",
                     "ActionOnFailure": "CONTINUE",
                     "HadoopJarStep": {
                       "Jar": "command-runner.jar",

--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -15,6 +15,7 @@ resource "aws_s3_bucket_object" "cluster" {
       instance_profile       = aws_iam_instance_profile.dataworks_aws_corporate_data_ingestion.arn
       security_configuration = aws_emr_security_configuration.ebs_emrfs_em.id
       emr_release            = var.emr_release[local.environment]
+      cluster_name           = local.emr_cluster_name
       environment_tag_value  = local.common_repo_tags.Environment
     }
   )

--- a/cluster_config/cluster.yaml.tpl
+++ b/cluster_config/cluster.yaml.tpl
@@ -6,7 +6,7 @@ Applications:
 CustomAmiId: "${ami_id}"
 EbsRootVolumeSize: 100
 LogUri: "s3://${s3_log_bucket}/${s3_log_prefix}"
-Name: "dataworks-aws-corporate-data-ingestion"
+Name: "${cluster_name}"
 ReleaseLabel: "emr-${emr_release}"
 SecurityConfiguration: "${security_configuration}"
 ScaleDownBehavior: "TERMINATE_AT_TASK_COMPLETION"

--- a/daily_export_scheduling.tf
+++ b/daily_export_scheduling.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_event_target" "run_daily_export" {
     "overrides": {
       "Steps": [{
         "Name": "corporate-data-ingestion::${each.key}::daily-run",
-        "ActionOnFailure": "CONTINUE",
+        "ActionOnFailure": "TERMINATE_CLUSTER",
         "HadoopJarStep": {
           "Jar": "command-runner.jar",
           "Args": [


### PR DESCRIPTION
- Daily processing fails loudly
- use better name for steps when triggered manually
- Ensure consistent naming
